### PR TITLE
missing one-word prepositions, added other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Titlecase Library for Haskell
+
+This library basically offers a rough but mostly working function `titlecase` to
+take any String and capitalize it according to English Title Case. While the
+Data.Text function `toTitle` simply capitalizes the first letter of every word,
+this Data.Text.Titlecase `titlecase` function uses the list of common words to
+not capitalize. It then respects the rule of capitalizing the first and last
+words regardless.
+
+On Hackage at <https://hackage.haskell.org/package/titlecase>.

--- a/src/Data/Text/Titlecase/Internal.hs
+++ b/src/Data/Text/Titlecase/Internal.hs
@@ -118,6 +118,11 @@ oneWordPrepositions = OneWordPreposition <$> fromList
   , "qua"
   , "regarding", "round"
   , "sans", "save", "since", "than", "through"
+  , "throughout", "thruout", "till", "times",
+  , "to", "toward", "towards", "under", "underneath",
+  , "unlike", "until", "unto", "up", "upon", "versus", "vs.", "vs", "v."
+  , "via", "vice", "vis-à-vis", "w/", "within", "w/in", "w/i", "without"
+  , "w/o", "worth"
   ]
 
 twoWordPrepositions :: NonEmpty Preposition

--- a/src/Data/Text/Titlecase/Internal.hs
+++ b/src/Data/Text/Titlecase/Internal.hs
@@ -97,13 +97,17 @@ prepositions
   <> threeWordPrepositions
   <> fourWordPrepositions
 
+-- | The words to not capitalize below come from Wikipedia
+-- primarily, https://en.wikipedia.org/wiki/List_of_English_prepositions
+-- but removing subordinating conjunctions generally
+-- see https://en.wikipedia.org/wiki/Conjunction_%28grammar%29#Subordinating_conjunctions
 oneWordPrepositions :: NonEmpty Preposition
 oneWordPrepositions = OneWordPreposition <$> fromList
   [ "a", "abaft", "abeam", "aboard", "about", "above", "absent", "across"
-  , "afore", "after", "against", "along", "alongside", "amid", "amidst"
-  , "among", "amongst", "an", "anenst", "apropos", "apud", "around", "as"
+  , "afore", "against", "along", "alongside", "amid", "amidst"
+  , "among", "amongst", "an", "anenst", "apropos", "apud", "around",
   , "aside", "astride", "at", "athwart", "atop"
-  , "barring", "before", "behind", "below", "beneath", "beside", "besides"
+  , "barring", "behind", "below", "beneath", "beside", "besides"
   , "between", "beyond", "but", "by"
   , "chez", "circa", "concerning", "considering"
   , "despite", "down", "during"
@@ -117,10 +121,10 @@ oneWordPrepositions = OneWordPreposition <$> fromList
   , "pace", "past", "per", "plus", "pro"
   , "qua"
   , "regarding", "round"
-  , "sans", "save", "since", "than", "through"
-  , "throughout", "thruout", "till", "times",
+  , "sans", "save", "through"
+  , "throughout", "till", "times",
   , "to", "toward", "towards", "under", "underneath",
-  , "unlike", "until", "unto", "up", "upon", "versus", "vs.", "vs", "v."
+  , "unlike", "unto", "up", "upon", "versus", "vs.", "vs", "v."
   , "via", "vice", "vis-à-vis", "w/", "within", "w/in", "w/i", "without"
   , "w/o", "worth"
   ]
@@ -130,7 +134,7 @@ twoWordPrepositions = uncurry TwoWordPreposition <$> fromList
   [ ("according", "to"), ("ahead", "of"), ("apart", "from"), ("as", "for")
   , ("as", "of"), ("as", "per"), ("as", "regards"), ("aside", "from")
   , ("astern", "of")
-  , ("back", "to"), ("because", "of")
+  , ("back", "to"),
   , ("close", "to")
   , ("due", "to")
   , ("except", "for")
@@ -149,8 +153,8 @@ twoWordPrepositions = uncurry TwoWordPreposition <$> fromList
 
 threeWordPrepositions :: NonEmpty Preposition
 threeWordPrepositions = uncurry3 ThreeWordPreposition <$> fromList
-  [ ("as", "far", "as"), ("as", "long", "as"), ("as", "opposed", "to")
-  , ("as", "soon", "as"), ("as", "well", "as")
+  [ ("as", "opposed", "to")
+  , ("as", "well", "as")
   , ("by", "means", "of"), ("by", "virtue", "of")
   , ("in", "accordance", "with"), ("in", "addition", "to")
   , ("in", "case", "of"), ("in", "front", "of"), ("in", "lieu", "of")


### PR DESCRIPTION
This obviously collected the Wikipedia list of English prepositions, but the one-word collection simply stopped short and was missing the whole end of the alphabet. Plus added README and another fix to word list.
