### PR TITLE
Add a 'titlecase' executable that capitalizes its command-line arguments.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,0 +1,10 @@
+module Main ( main ) where
+
+import Data.Text ( pack )
+import Data.Text.Titlecase
+import System.Environment
+import Text.Blaze
+import Text.Blaze.Renderer.Pretty
+
+main :: IO ()
+main = getArgs >>= putStr . renderMarkup . toMarkup . titlecase . pack . unwords

--- a/titlecase.cabal
+++ b/titlecase.cabal
@@ -36,6 +36,14 @@ library
                      , semigroups
                      , text
 
+executable titlecase
+  default-language:    Haskell2010
+  main-is:             Main.hs
+  build-depends:       base < 5
+                     , blaze-markup
+                     , text
+                     , titlecase
+
 test-suite test
   default-language:    Haskell2010
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
```
$ cabal -v0 run titlecase -- titlecase is a useful shell utility to have
Titlecase Is a Useful Shell Utility to Have
```
